### PR TITLE
Add aluminium slim profile glass shutter calculator

### DIFF
--- a/shutter-calculator.html
+++ b/shutter-calculator.html
@@ -1,0 +1,263 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Aluminium Slim Profile Glass Shutter Calculator</title>
+    <style>
+      body {
+        font-family: Arial, sans-serif;
+        margin: 20px;
+      }
+
+      fieldset {
+        border: 1px solid #aaa;
+        border-radius: 6px;
+        margin-bottom: 20px;
+        padding: 10px 15px;
+      }
+
+      legend {
+        font-weight: bold;
+        color: #2e7d32;
+      }
+
+      label {
+        display: inline-block;
+        margin: 5px 15px 5px 0;
+      }
+
+      input[type="number"], select {
+        width: 90px;
+        padding: 4px;
+      }
+
+      table {
+        border: 2px solid black;
+        border-collapse: collapse;
+        margin-bottom: 20px;
+      }
+
+      td, th {
+        padding: 5px;
+        border: 1px solid black;
+        text-align: center;
+      }
+
+      th {
+        background: #f0f0f0;
+      }
+
+      tfoot td {
+        background: #e8f5e9;
+        font-weight: bold;
+      }
+
+      button {
+        padding: 6px 14px;
+        margin: 5px 5px 5px 0;
+        cursor: pointer;
+      }
+
+      #grand-total {
+        font-size: 1.3em;
+        color: #2e7d32;
+      }
+
+      .remove-btn {
+        color: #b00;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Aluminium Slim Profile Glass Shutter Calculator</h1>
+    <p>Cabinet/wardrobe-এর slim aluminium profile glass shutter-এর জন্য profile, glass আর accessories-এর হিসাব। প্রতিটা shutter-এর width, height আর quantity দিন — নিচে material আর cost breakdown চলে আসবে।</p>
+
+    <fieldset>
+      <legend>Settings / Rates</legend>
+      <label>Measurement unit:
+        <select id="unit">
+          <option value="mm" selected>mm</option>
+          <option value="inch">inch</option>
+        </select>
+      </label>
+      <label>Glass deduction (per side, mm): <input type="number" id="glass-deduction" value="9" min="0" step="0.5"></label>
+      <label>Profile wastage (%): <input type="number" id="wastage" value="5" min="0" step="1"></label>
+      <br>
+      <label>Profile rate (Tk/ft): <input type="number" id="rate-profile" value="120" min="0" step="1"></label>
+      <label>Glass rate (Tk/sqft): <input type="number" id="rate-glass" value="180" min="0" step="1"></label>
+      <label>Gasket rate (Tk/ft): <input type="number" id="rate-gasket" value="10" min="0" step="1"></label>
+      <br>
+      <label>Corner joint (Tk/pc): <input type="number" id="rate-corner" value="15" min="0" step="1"></label>
+      <label>Hinge (Tk/pc): <input type="number" id="rate-hinge" value="90" min="0" step="1"></label>
+      <label>Handle (Tk/pc): <input type="number" id="rate-handle" value="150" min="0" step="1"></label>
+    </fieldset>
+
+    <fieldset>
+      <legend>Shutters</legend>
+      <table id="shutter-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Width</th>
+            <th>Height</th>
+            <th>Qty</th>
+            <th>Glass size (mm)</th>
+            <th>Profile (ft)</th>
+            <th>Glass (sqft)</th>
+            <th>Hinges</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="shutter-rows"></tbody>
+      </table>
+      <button type="button" id="add-row">+ Add shutter</button>
+    </fieldset>
+
+    <h2>Material Summary</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Item</th>
+          <th>Quantity</th>
+          <th>Rate (Tk)</th>
+          <th>Cost (Tk)</th>
+        </tr>
+      </thead>
+      <tbody id="summary-rows"></tbody>
+      <tfoot>
+        <tr>
+          <td colspan="3">Grand Total</td>
+          <td id="grand-total">0</td>
+        </tr>
+      </tfoot>
+    </table>
+
+    <p><small>
+      Note: Profile লাগে shutter-এর চারপাশে = 2 × (width + height), তার উপর wastage যোগ হয়।
+      Glass size = shutter size থেকে প্রতি পাশে glass deduction বাদ (profile-এর groove-এ glass ঢোকার জন্য) —
+      আপনার profile অনুযায়ী deduction বদলে নিন। Gasket glass-এর perimeter ধরে হিসাব করা হয়।
+      Hinge: height 1000mm পর্যন্ত 2টা, তার বেশি হলে 3টা। প্রতি shutter-এ 4টা corner joint আর 1টা handle ধরা হয়েছে।
+    </small></p>
+
+    <script>
+      var MM_PER_INCH = 25.4;
+      var MM_PER_FOOT = 304.8;
+
+      var shutterRows = document.getElementById('shutter-rows');
+
+      function addRow(width, height, qty) {
+        var tr = document.createElement('tr');
+        tr.innerHTML =
+          '<td class="row-no"></td>' +
+          '<td><input type="number" class="width" min="0" step="any" value="' + (width || '') + '"></td>' +
+          '<td><input type="number" class="height" min="0" step="any" value="' + (height || '') + '"></td>' +
+          '<td><input type="number" class="qty" min="1" step="1" value="' + (qty || 1) + '"></td>' +
+          '<td class="out-glass-size">-</td>' +
+          '<td class="out-profile">-</td>' +
+          '<td class="out-glass-area">-</td>' +
+          '<td class="out-hinges">-</td>' +
+          '<td><button type="button" class="remove-btn">✕</button></td>';
+        tr.querySelector('.remove-btn').addEventListener('click', function () {
+          tr.parentNode.removeChild(tr);
+          calculate();
+        });
+        shutterRows.appendChild(tr);
+      }
+
+      function toMm(value) {
+        return document.getElementById('unit').value === 'inch' ? value * MM_PER_INCH : value;
+      }
+
+      function num(id) {
+        return parseFloat(document.getElementById(id).value) || 0;
+      }
+
+      function calculate() {
+        var deduction = num('glass-deduction');
+        var wastage = num('wastage') / 100;
+
+        var totalProfileFt = 0;
+        var totalGlassSqft = 0;
+        var totalGasketFt = 0;
+        var totalCorners = 0;
+        var totalHinges = 0;
+        var totalHandles = 0;
+
+        var rows = shutterRows.querySelectorAll('tr');
+        for (var i = 0; i < rows.length; i++) {
+          var row = rows[i];
+          row.querySelector('.row-no').textContent = i + 1;
+
+          var w = toMm(parseFloat(row.querySelector('.width').value) || 0);
+          var h = toMm(parseFloat(row.querySelector('.height').value) || 0);
+          var qty = parseInt(row.querySelector('.qty').value, 10) || 0;
+
+          if (w <= 0 || h <= 0 || qty <= 0) {
+            row.querySelector('.out-glass-size').textContent = '-';
+            row.querySelector('.out-profile').textContent = '-';
+            row.querySelector('.out-glass-area').textContent = '-';
+            row.querySelector('.out-hinges').textContent = '-';
+            continue;
+          }
+
+          var glassW = Math.max(w - 2 * deduction, 0);
+          var glassH = Math.max(h - 2 * deduction, 0);
+
+          var profileFt = 2 * (w + h) / MM_PER_FOOT * qty;
+          var glassSqft = (glassW / MM_PER_FOOT) * (glassH / MM_PER_FOOT) * qty;
+          var gasketFt = 2 * (glassW + glassH) / MM_PER_FOOT * qty;
+          var hingesPerShutter = h > 1000 ? 3 : 2;
+
+          row.querySelector('.out-glass-size').textContent = glassW.toFixed(1) + ' × ' + glassH.toFixed(1);
+          row.querySelector('.out-profile').textContent = profileFt.toFixed(2);
+          row.querySelector('.out-glass-area').textContent = glassSqft.toFixed(2);
+          row.querySelector('.out-hinges').textContent = hingesPerShutter * qty;
+
+          totalProfileFt += profileFt;
+          totalGlassSqft += glassSqft;
+          totalGasketFt += gasketFt;
+          totalCorners += 4 * qty;
+          totalHinges += hingesPerShutter * qty;
+          totalHandles += qty;
+        }
+
+        var profileWithWastage = totalProfileFt * (1 + wastage);
+
+        var items = [
+          ['Aluminium profile (with ' + num('wastage') + '% wastage)', profileWithWastage.toFixed(2) + ' ft', num('rate-profile'), profileWithWastage * num('rate-profile')],
+          ['Glass', totalGlassSqft.toFixed(2) + ' sqft', num('rate-glass'), totalGlassSqft * num('rate-glass')],
+          ['Gasket', totalGasketFt.toFixed(2) + ' ft', num('rate-gasket'), totalGasketFt * num('rate-gasket')],
+          ['Corner joint', totalCorners + ' pcs', num('rate-corner'), totalCorners * num('rate-corner')],
+          ['Hinge', totalHinges + ' pcs', num('rate-hinge'), totalHinges * num('rate-hinge')],
+          ['Handle', totalHandles + ' pcs', num('rate-handle'), totalHandles * num('rate-handle')]
+        ];
+
+        var summary = document.getElementById('summary-rows');
+        summary.innerHTML = '';
+        var grand = 0;
+        items.forEach(function (item) {
+          grand += item[3];
+          var tr = document.createElement('tr');
+          tr.innerHTML =
+            '<td style="text-align:left">' + item[0] + '</td>' +
+            '<td>' + item[1] + '</td>' +
+            '<td>' + item[2] + '</td>' +
+            '<td>' + item[3].toFixed(2) + '</td>';
+          summary.appendChild(tr);
+        });
+        document.getElementById('grand-total').textContent = grand.toFixed(2) + ' Tk';
+      }
+
+      document.getElementById('add-row').addEventListener('click', function () {
+        addRow();
+        calculate();
+      });
+
+      document.body.addEventListener('input', calculate);
+      document.getElementById('unit').addEventListener('change', calculate);
+
+      addRow(450, 700, 1);
+      calculate();
+    </script>
+  </body>
+</html>

--- a/shutter-calculator.html
+++ b/shutter-calculator.html
@@ -26,9 +26,28 @@
         margin: 5px 15px 5px 0;
       }
 
-      input[type="number"], input[type="text"], select {
-        width: 90px;
+      input[type="number"], select {
         padding: 4px;
+      }
+
+      fieldset input[type="number"] {
+        width: 90px;
+      }
+
+      .dim-mm {
+        width: 80px;
+      }
+
+      .dim-ft, .dim-in {
+        width: 55px;
+      }
+
+      .dim-suta {
+        width: 75px;
+      }
+
+      .qty {
+        width: 55px;
       }
 
       table {
@@ -70,9 +89,14 @@
       #format-hint {
         color: #555;
       }
+
+      /* show only the boxes for the selected unit */
+      body.unit-mm .dim-ft, body.unit-mm .dim-in, body.unit-mm .dim-suta { display: none; }
+      body.unit-inch .dim-mm, body.unit-inch .dim-ft { display: none; }
+      body.unit-ft .dim-mm { display: none; }
     </style>
   </head>
-  <body>
+  <body class="unit-mm">
     <h1>Aluminium Slim Profile Glass Shutter Calculator</h1>
     <p>Cabinet/wardrobe-এর slim aluminium profile glass shutter-এর জন্য profile, glass আর accessories-এর হিসাব। প্রতিটা shutter-এর width, height আর quantity দিন — নিচে material আর cost breakdown চলে আসবে।</p>
 
@@ -81,8 +105,8 @@
       <label>Measurement unit:
         <select id="unit">
           <option value="mm" selected>mm</option>
-          <option value="inch">inch (সুতা)</option>
-          <option value="ft">ft (ইঞ্চি-সুতা)</option>
+          <option value="inch">inch + সুতা</option>
+          <option value="ft">ft + inch + সুতা</option>
         </select>
       </label>
       <label>Glass deduction (per side, mm): <input type="number" id="glass-deduction" value="9" min="0" step="0.5"></label>
@@ -145,8 +169,8 @@
       আপনার profile অনুযায়ী deduction বদলে নিন। Gasket glass-এর perimeter ধরে হিসাব করা হয়।
       Hinge: height 1000mm পর্যন্ত 2টা, তার বেশি হলে 3টা। প্রতি shutter-এ 4টা corner joint আর 1টা handle ধরা হয়েছে।
       <br>
-      ১ সুতা = ১/৮ ইঞ্চি। inch mode-এ লিখুন: <b>2"3</b> বা <b>2-3</b> (২ ইঞ্চি ৩ সুতা), <b>2 3/8</b>, অথবা <b>2.375</b>।
-      ft mode-এ লিখুন: <b>4'6"3</b> (৪ ফুট ৬ ইঞ্চি ৩ সুতা), <b>4'6</b>, অথবা <b>4.5</b>।
+      1 সুতা = 1/8 ইঞ্চি। inch বা ft mode-এ inch-এর ঘরের পাশে সুতার ঘর থেকে 0–7 select করুন (default 0)।
+      যেমন: 3 inch 2 সুতা = inch-এর ঘরে 3, সুতার ঘরে 2।
     </small></p>
 
     <script>
@@ -156,47 +180,46 @@
       var shutterRows = document.getElementById('shutter-rows');
 
       var UNIT_INFO = {
-        mm:   { label: 'mm',            placeholder: '450',    hint: 'সরাসরি mm-এ লিখুন, যেমন: 450' },
-        inch: { label: 'inch-সুতা',     placeholder: '2"3',    hint: 'ইঞ্চি-সুতা format: 2"3 বা 2-3 = ২ ইঞ্চি ৩ সুতা (৩/৮"), 2 3/8 বা 2.375-ও চলবে' },
-        ft:   { label: "ft-inch-সুতা",  placeholder: "4'6\"3", hint: "ফুট-ইঞ্চি-সুতা format: 4'6\"3 = ৪ ফুট ৬ ইঞ্চি ৩ সুতা, 4'6 বা 4.5-ও চলবে" }
+        mm:   { label: 'mm',              hint: 'সরাসরি mm-এ লিখুন, যেমন: 450' },
+        inch: { label: 'inch + সুতা',     hint: 'inch-এর ঘরে inch লিখুন, পাশের ঘরে সুতা (0-7) select করুন। যেমন: 3 inch 2 সুতা' },
+        ft:   { label: 'ft + inch + সুতা', hint: 'ft, inch আর সুতা (0-7) আলাদা ঘরে দিন। যেমন: 4 ft 6 inch 3 সুতা' }
       };
 
       function currentUnit() {
         return document.getElementById('unit').value;
       }
 
-      // "2"3" / "2-3" / "2 3" => 2 inch 3 suta (suta = 1/8"), "2 3/8" => 2 + 3/8, "3/8" => 0.375, "2.375" => 2.375
-      function parseInches(str) {
-        str = String(str).trim();
-        if (!str) return 0;
-        var m = str.match(/^(?:(\d+(?:\.\d+)?)\s*["\s-]+)?(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\s*"?$/);
-        if (m) {
-          return (parseFloat(m[1]) || 0) + parseFloat(m[2]) / (parseFloat(m[3]) || 1);
+      function sutaOptions() {
+        var html = '';
+        for (var s = 0; s <= 7; s++) {
+          html += '<option value="' + s + '">' + s + ' সুতা</option>';
         }
-        m = str.match(/^(\d+(?:\.\d+)?)\s*["\s-]+\s*(\d+(?:\.\d+)?)\s*"?$/);
-        if (m) {
-          return parseFloat(m[1]) + parseFloat(m[2]) / 8;
-        }
-        return parseFloat(str) || 0;
+        return html;
       }
 
-      function parseDimToMm(str, unit) {
-        str = String(str).trim();
-        if (!str) return 0;
-        if (unit === 'mm') return parseFloat(str) || 0;
-        if (unit === 'inch') return parseInches(str) * MM_PER_INCH;
-        // ft: 4'6"3 = 4 ft + 6 inch 3 suta, plain number = decimal ft
-        var m = str.match(/^(\d+(?:\.\d+)?)\s*(?:'|ft)\s*(.*)$/);
-        if (m) {
-          var rest = m[2].replace(/^[\s-]+/, '');
-          return parseFloat(m[1]) * MM_PER_FOOT + (rest ? parseInches(rest) * MM_PER_INCH : 0);
+      function dimCell(cls, mmValue) {
+        return '<td class="' + cls + '">' +
+          '<input type="number" class="dim-mm" min="0" step="any" placeholder="mm" value="' + (mmValue || '') + '">' +
+          '<input type="number" class="dim-ft" min="0" step="1" placeholder="ft">' +
+          '<input type="number" class="dim-in" min="0" step="any" placeholder="inch">' +
+          '<select class="dim-suta">' + sutaOptions() + '</select>' +
+          '</td>';
+      }
+
+      // dimension of one cell in mm, based on the selected unit's visible boxes
+      function cellToMm(cell, unit) {
+        function v(sel) {
+          return parseFloat(cell.querySelector(sel).value) || 0;
         }
-        return (parseFloat(str) || 0) * MM_PER_FOOT;
+        if (unit === 'mm') return v('.dim-mm');
+        var inches = v('.dim-in') + v('.dim-suta') / 8;
+        if (unit === 'ft') inches += v('.dim-ft') * 12;
+        return inches * MM_PER_INCH;
       }
 
       // mm => display string in the current unit (inch/ft rounded to the nearest suta)
       function formatDim(mm, unit) {
-        if (unit === 'mm') return mm.toFixed(1);
+        if (unit === 'mm') return mm.toFixed(1) + ' mm';
         var totalIn = mm / MM_PER_INCH;
         var ft = 0;
         if (unit === 'ft') {
@@ -207,16 +230,19 @@
         var suta = Math.round((totalIn - whole) * 8);
         if (suta === 8) { whole++; suta = 0; }
         if (unit === 'ft' && whole === 12) { ft++; whole = 0; }
-        return (unit === 'ft' ? ft + "'" : '') + whole + '"' + suta;
+        var out = '';
+        if (unit === 'ft') out += ft + "' ";
+        out += whole + '"';
+        if (suta > 0) out += ' ' + suta + ' সুতা';
+        return out;
       }
 
-      function addRow(width, height, qty) {
-        var placeholder = UNIT_INFO[currentUnit()].placeholder;
+      function addRow(widthMm, heightMm, qty) {
         var tr = document.createElement('tr');
         tr.innerHTML =
           '<td class="row-no"></td>' +
-          '<td><input type="text" class="width" inputmode="decimal" placeholder="' + placeholder + '" value="' + (width || '') + '"></td>' +
-          '<td><input type="text" class="height" inputmode="decimal" placeholder="' + placeholder + '" value="' + (height || '') + '"></td>' +
+          dimCell('cell-width', widthMm) +
+          dimCell('cell-height', heightMm) +
           '<td><input type="number" class="qty" min="1" step="1" value="' + (qty || 1) + '"></td>' +
           '<td class="out-glass-size">-</td>' +
           '<td class="out-profile">-</td>' +
@@ -235,15 +261,13 @@
       }
 
       function updateUnitUi() {
-        var info = UNIT_INFO[currentUnit()];
+        var unit = currentUnit();
+        var info = UNIT_INFO[unit];
+        document.body.className = 'unit-' + unit;
         document.getElementById('th-width').textContent = 'Width (' + info.label + ')';
         document.getElementById('th-height').textContent = 'Height (' + info.label + ')';
         document.getElementById('th-glass-size').textContent = 'Glass size (' + info.label + ')';
         document.getElementById('format-hint').textContent = info.hint;
-        var inputs = shutterRows.querySelectorAll('.width, .height');
-        for (var i = 0; i < inputs.length; i++) {
-          inputs[i].placeholder = info.placeholder;
-        }
       }
 
       function calculate() {
@@ -263,8 +287,8 @@
           var row = rows[i];
           row.querySelector('.row-no').textContent = i + 1;
 
-          var w = parseDimToMm(row.querySelector('.width').value, unit);
-          var h = parseDimToMm(row.querySelector('.height').value, unit);
+          var w = cellToMm(row.querySelector('.cell-width'), unit);
+          var h = cellToMm(row.querySelector('.cell-height'), unit);
           var qty = parseInt(row.querySelector('.qty').value, 10) || 0;
 
           if (w <= 0 || h <= 0 || qty <= 0) {
@@ -329,10 +353,8 @@
       });
 
       document.body.addEventListener('input', calculate);
-      document.getElementById('unit').addEventListener('change', function () {
-        updateUnitUi();
-        calculate();
-      });
+      document.body.addEventListener('change', calculate);
+      document.getElementById('unit').addEventListener('change', updateUnitUi);
 
       addRow(450, 700, 1);
       updateUnitUi();

--- a/shutter-calculator.html
+++ b/shutter-calculator.html
@@ -26,7 +26,7 @@
         margin: 5px 15px 5px 0;
       }
 
-      input[type="number"], select {
+      input[type="number"], input[type="text"], select {
         width: 90px;
         padding: 4px;
       }
@@ -66,6 +66,10 @@
       .remove-btn {
         color: #b00;
       }
+
+      #format-hint {
+        color: #555;
+      }
     </style>
   </head>
   <body>
@@ -77,11 +81,14 @@
       <label>Measurement unit:
         <select id="unit">
           <option value="mm" selected>mm</option>
-          <option value="inch">inch</option>
+          <option value="inch">inch (সুতা)</option>
+          <option value="ft">ft (ইঞ্চি-সুতা)</option>
         </select>
       </label>
       <label>Glass deduction (per side, mm): <input type="number" id="glass-deduction" value="9" min="0" step="0.5"></label>
       <label>Profile wastage (%): <input type="number" id="wastage" value="5" min="0" step="1"></label>
+      <br>
+      <span id="format-hint"></span>
       <br>
       <label>Profile rate (Tk/ft): <input type="number" id="rate-profile" value="120" min="0" step="1"></label>
       <label>Glass rate (Tk/sqft): <input type="number" id="rate-glass" value="180" min="0" step="1"></label>
@@ -98,10 +105,10 @@
         <thead>
           <tr>
             <th>#</th>
-            <th>Width</th>
-            <th>Height</th>
+            <th id="th-width">Width</th>
+            <th id="th-height">Height</th>
             <th>Qty</th>
-            <th>Glass size (mm)</th>
+            <th id="th-glass-size">Glass size</th>
             <th>Profile (ft)</th>
             <th>Glass (sqft)</th>
             <th>Hinges</th>
@@ -137,6 +144,9 @@
       Glass size = shutter size থেকে প্রতি পাশে glass deduction বাদ (profile-এর groove-এ glass ঢোকার জন্য) —
       আপনার profile অনুযায়ী deduction বদলে নিন। Gasket glass-এর perimeter ধরে হিসাব করা হয়।
       Hinge: height 1000mm পর্যন্ত 2টা, তার বেশি হলে 3টা। প্রতি shutter-এ 4টা corner joint আর 1টা handle ধরা হয়েছে।
+      <br>
+      ১ সুতা = ১/৮ ইঞ্চি। inch mode-এ লিখুন: <b>2"3</b> বা <b>2-3</b> (২ ইঞ্চি ৩ সুতা), <b>2 3/8</b>, অথবা <b>2.375</b>।
+      ft mode-এ লিখুন: <b>4'6"3</b> (৪ ফুট ৬ ইঞ্চি ৩ সুতা), <b>4'6</b>, অথবা <b>4.5</b>।
     </small></p>
 
     <script>
@@ -145,12 +155,68 @@
 
       var shutterRows = document.getElementById('shutter-rows');
 
+      var UNIT_INFO = {
+        mm:   { label: 'mm',            placeholder: '450',    hint: 'সরাসরি mm-এ লিখুন, যেমন: 450' },
+        inch: { label: 'inch-সুতা',     placeholder: '2"3',    hint: 'ইঞ্চি-সুতা format: 2"3 বা 2-3 = ২ ইঞ্চি ৩ সুতা (৩/৮"), 2 3/8 বা 2.375-ও চলবে' },
+        ft:   { label: "ft-inch-সুতা",  placeholder: "4'6\"3", hint: "ফুট-ইঞ্চি-সুতা format: 4'6\"3 = ৪ ফুট ৬ ইঞ্চি ৩ সুতা, 4'6 বা 4.5-ও চলবে" }
+      };
+
+      function currentUnit() {
+        return document.getElementById('unit').value;
+      }
+
+      // "2"3" / "2-3" / "2 3" => 2 inch 3 suta (suta = 1/8"), "2 3/8" => 2 + 3/8, "3/8" => 0.375, "2.375" => 2.375
+      function parseInches(str) {
+        str = String(str).trim();
+        if (!str) return 0;
+        var m = str.match(/^(?:(\d+(?:\.\d+)?)\s*["\s-]+)?(\d+(?:\.\d+)?)\s*\/\s*(\d+(?:\.\d+)?)\s*"?$/);
+        if (m) {
+          return (parseFloat(m[1]) || 0) + parseFloat(m[2]) / (parseFloat(m[3]) || 1);
+        }
+        m = str.match(/^(\d+(?:\.\d+)?)\s*["\s-]+\s*(\d+(?:\.\d+)?)\s*"?$/);
+        if (m) {
+          return parseFloat(m[1]) + parseFloat(m[2]) / 8;
+        }
+        return parseFloat(str) || 0;
+      }
+
+      function parseDimToMm(str, unit) {
+        str = String(str).trim();
+        if (!str) return 0;
+        if (unit === 'mm') return parseFloat(str) || 0;
+        if (unit === 'inch') return parseInches(str) * MM_PER_INCH;
+        // ft: 4'6"3 = 4 ft + 6 inch 3 suta, plain number = decimal ft
+        var m = str.match(/^(\d+(?:\.\d+)?)\s*(?:'|ft)\s*(.*)$/);
+        if (m) {
+          var rest = m[2].replace(/^[\s-]+/, '');
+          return parseFloat(m[1]) * MM_PER_FOOT + (rest ? parseInches(rest) * MM_PER_INCH : 0);
+        }
+        return (parseFloat(str) || 0) * MM_PER_FOOT;
+      }
+
+      // mm => display string in the current unit (inch/ft rounded to the nearest suta)
+      function formatDim(mm, unit) {
+        if (unit === 'mm') return mm.toFixed(1);
+        var totalIn = mm / MM_PER_INCH;
+        var ft = 0;
+        if (unit === 'ft') {
+          ft = Math.floor(totalIn / 12);
+          totalIn -= ft * 12;
+        }
+        var whole = Math.floor(totalIn);
+        var suta = Math.round((totalIn - whole) * 8);
+        if (suta === 8) { whole++; suta = 0; }
+        if (unit === 'ft' && whole === 12) { ft++; whole = 0; }
+        return (unit === 'ft' ? ft + "'" : '') + whole + '"' + suta;
+      }
+
       function addRow(width, height, qty) {
+        var placeholder = UNIT_INFO[currentUnit()].placeholder;
         var tr = document.createElement('tr');
         tr.innerHTML =
           '<td class="row-no"></td>' +
-          '<td><input type="number" class="width" min="0" step="any" value="' + (width || '') + '"></td>' +
-          '<td><input type="number" class="height" min="0" step="any" value="' + (height || '') + '"></td>' +
+          '<td><input type="text" class="width" inputmode="decimal" placeholder="' + placeholder + '" value="' + (width || '') + '"></td>' +
+          '<td><input type="text" class="height" inputmode="decimal" placeholder="' + placeholder + '" value="' + (height || '') + '"></td>' +
           '<td><input type="number" class="qty" min="1" step="1" value="' + (qty || 1) + '"></td>' +
           '<td class="out-glass-size">-</td>' +
           '<td class="out-profile">-</td>' +
@@ -164,15 +230,24 @@
         shutterRows.appendChild(tr);
       }
 
-      function toMm(value) {
-        return document.getElementById('unit').value === 'inch' ? value * MM_PER_INCH : value;
-      }
-
       function num(id) {
         return parseFloat(document.getElementById(id).value) || 0;
       }
 
+      function updateUnitUi() {
+        var info = UNIT_INFO[currentUnit()];
+        document.getElementById('th-width').textContent = 'Width (' + info.label + ')';
+        document.getElementById('th-height').textContent = 'Height (' + info.label + ')';
+        document.getElementById('th-glass-size').textContent = 'Glass size (' + info.label + ')';
+        document.getElementById('format-hint').textContent = info.hint;
+        var inputs = shutterRows.querySelectorAll('.width, .height');
+        for (var i = 0; i < inputs.length; i++) {
+          inputs[i].placeholder = info.placeholder;
+        }
+      }
+
       function calculate() {
+        var unit = currentUnit();
         var deduction = num('glass-deduction');
         var wastage = num('wastage') / 100;
 
@@ -188,8 +263,8 @@
           var row = rows[i];
           row.querySelector('.row-no').textContent = i + 1;
 
-          var w = toMm(parseFloat(row.querySelector('.width').value) || 0);
-          var h = toMm(parseFloat(row.querySelector('.height').value) || 0);
+          var w = parseDimToMm(row.querySelector('.width').value, unit);
+          var h = parseDimToMm(row.querySelector('.height').value, unit);
           var qty = parseInt(row.querySelector('.qty').value, 10) || 0;
 
           if (w <= 0 || h <= 0 || qty <= 0) {
@@ -208,7 +283,7 @@
           var gasketFt = 2 * (glassW + glassH) / MM_PER_FOOT * qty;
           var hingesPerShutter = h > 1000 ? 3 : 2;
 
-          row.querySelector('.out-glass-size').textContent = glassW.toFixed(1) + ' × ' + glassH.toFixed(1);
+          row.querySelector('.out-glass-size').textContent = formatDim(glassW, unit) + ' × ' + formatDim(glassH, unit);
           row.querySelector('.out-profile').textContent = profileFt.toFixed(2);
           row.querySelector('.out-glass-area').textContent = glassSqft.toFixed(2);
           row.querySelector('.out-hinges').textContent = hingesPerShutter * qty;
@@ -254,9 +329,13 @@
       });
 
       document.body.addEventListener('input', calculate);
-      document.getElementById('unit').addEventListener('change', calculate);
+      document.getElementById('unit').addEventListener('change', function () {
+        updateUnitUi();
+        calculate();
+      });
 
       addRow(450, 700, 1);
+      updateUnitUi();
       calculate();
     </script>
   </body>

--- a/shutter-calculator.html
+++ b/shutter-calculator.html
@@ -90,13 +90,25 @@
         color: #555;
       }
 
+      .dim-grp {
+        display: inline-block;
+        white-space: nowrap;
+        margin: 1px 3px;
+      }
+
+      .dim-grp small {
+        color: #555;
+        margin-left: 2px;
+      }
+
       /* show only the boxes for the selected unit */
-      body.unit-mm .dim-ft, body.unit-mm .dim-in, body.unit-mm .dim-suta { display: none; }
-      body.unit-inch .dim-mm, body.unit-inch .dim-ft { display: none; }
-      body.unit-ft .dim-mm { display: none; }
+      body.unit-mm .grp-ft, body.unit-mm .grp-in, body.unit-mm .grp-suta { display: none; }
+      body.unit-inch .grp-mm, body.unit-inch .grp-ft { display: none; }
+      body.unit-ft .grp-mm { display: none; }
     </style>
   </head>
   <body class="unit-mm">
+    <noscript><p style="color:#b00"><b>এই page-টা চালাতে JavaScript লাগবে — file-টা download করে browser-এ খুলুন।</b></p></noscript>
     <h1>Aluminium Slim Profile Glass Shutter Calculator</h1>
     <p>Cabinet/wardrobe-এর slim aluminium profile glass shutter-এর জন্য profile, glass আর accessories-এর হিসাব। প্রতিটা shutter-এর width, height আর quantity দিন — নিচে material আর cost breakdown চলে আসবে।</p>
 
@@ -199,10 +211,10 @@
 
       function dimCell(cls, mmValue) {
         return '<td class="' + cls + '">' +
-          '<input type="number" class="dim-mm" min="0" step="any" placeholder="mm" value="' + (mmValue || '') + '">' +
-          '<input type="number" class="dim-ft" min="0" step="1" placeholder="ft">' +
-          '<input type="number" class="dim-in" min="0" step="any" placeholder="inch">' +
-          '<select class="dim-suta">' + sutaOptions() + '</select>' +
+          '<span class="dim-grp grp-mm"><input type="number" class="dim-mm" min="0" step="any" value="' + (mmValue || '') + '"><small>mm</small></span>' +
+          '<span class="dim-grp grp-ft"><input type="number" class="dim-ft" min="0" step="1"><small>ft</small></span>' +
+          '<span class="dim-grp grp-in"><input type="number" class="dim-in" min="0" step="any"><small>inch</small></span>' +
+          '<span class="dim-grp grp-suta"><select class="dim-suta">' + sutaOptions() + '</select></span>' +
           '</td>';
       }
 


### PR DESCRIPTION
## Summary

Adds `shutter-calculator.html`, a standalone calculator for aluminium slim profile glass shutters (cabinet/wardrobe doors):

- Enter any number of shutters (width, height, quantity) in mm or inch
- Per shutter it computes the **glass cutting size** (shutter size minus an editable per-side glass deduction for the profile groove), **profile length in feet**, **glass area in sqft**, and **hinge count** (2 up to 1000mm height, 3 above)
- Material summary totals: aluminium profile (with editable wastage %), glass, gasket (glass perimeter), corner joints (4/shutter), hinges, and handles (1/shutter)
- Every material has an editable rate, and the page shows a per-item cost breakdown plus a grand total in Tk
- Fully self-contained (no libraries), styled to match the existing pages in this repo, with Bengali+English UI text like `excel-import.html`

## How to test

1. Open `shutter-calculator.html` in a browser
2. The default 450×700mm shutter shows glass 432×682mm, 7.55 ft profile, 3.17 sqft glass, 2 hinges
3. Add more shutters, change rates/deduction/wastage, or switch to inches — everything recalculates live

Verified headlessly with Chromium/Playwright: glass deduction, profile footage, hinge rule, inch conversion, and row add/remove all produce the expected numbers with no console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WKYBPtbj4jEACnScvi4dZx

---
_Generated by [Claude Code](https://claude.ai/code/session_01WKYBPtbj4jEACnScvi4dZx)_